### PR TITLE
Support for the 'server' clause in named.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ bin/*
 sloccount.sc
 checkstyle.xml
 .coverage
+
+Berksfile.lock.bak
+Thorfile
+Vagrantfile

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,3 +20,6 @@ suites:
       zones:
         attribute: [ "example.com" ]
       options: [ "check-names slave ignore;", "multi-master yes;", "provide-ixfr yes;", "request-ixfr yes;" ]
+      server:
+        127.0.0.1:
+        - 'bogus no;'

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The net-ldap v0.2.2 Ruby gem is required for the ldap2zone recipe.
   - Integer for statistics-channel TCP port.
   - Default, 8080
 
+* `bind['server']
+  - Hash of server IPs, each with their own array of options for the "server" clause.
+  - Will not populate by default
+
 ### Attributes which should not require tuning
 
 * `bind['packages']`
@@ -297,6 +301,14 @@ use the following format to include a number of zones at once.
 {
   "id": "example",
   "zones": [ "example.com", "example.org" ]
+}
+```
+
+### Example of using the 'server' clause
+```ruby
+default['bind']['server'] = {
+  10.0.0.1: ['keys { my_tsig_key; };', 'bogus no;'],
+  10.0.0.2: ['bogus yes;']
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The net-ldap v0.2.2 Ruby gem is required for the ldap2zone recipe.
   - An array attribute where zone names may be set from a
     databag source.
 
+* `bind['forwardzones']`
+  - An array of zones to forward requests for.
+
+* `bind['forwarders']`
+  - An array of forwarders to use with the forwardzones.
+
 * `bind['zonetype']`
   - The zone type, master, or slave for configuring
     the  named.conf template.

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ task :deploy do
 end
 
 # default tasks are quick, commit tests
-task :default => ['foodcritic', 'rubocop', 'chefspec']
+task default: %w( foodcritic rubocop chefspec )
 
 # jenkins tasks format for metric tracking
-task :jenkins => ['foodcritic', 'rubocop_checkformat', 'chefspec'] 
+task jenkins: %w( foodcritic rubocop_checkformat chefspec )

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,6 +53,9 @@ default['bind']['var_cookbook_files'] = %w(named.empty named.ca named.loopback n
 # This an array of masters, or servers which you transfer from.
 default['bind']['masters'] = []
 
+# Set DNS BIND Server Clause options
+default['bind']['server'] = {}
+
 # Boolean to turn off/on IPV6 support
 default['bind']['ipv6_listen'] = false
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,6 +53,12 @@ default['bind']['var_cookbook_files'] = %w(named.empty named.ca named.loopback n
 # This an array of masters, or servers which you transfer from.
 default['bind']['masters'] = []
 
+# This an array of forwarders, or servers which I will query upstream
+default['bind']['forwarders'] = []
+
+# Zones that should use the forwarders
+default['bind']['forwardzones'] = []
+
 # Set DNS BIND Server Clause options
 default['bind']['server'] = {}
 

--- a/chefignore
+++ b/chefignore
@@ -94,3 +94,7 @@ Vagrantfile
 # Travis #
 ##########
 .travis.yml
+
+# Kitchen
+.kitchen
+.kitchen.local*

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,5 +3,5 @@ maintainer_email 'wolfe21@marshall.edu'
 license          'Apache 2.0'
 description      'Installs/Configures ISC BIND'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.2'
+version          '1.0.3'
 name             'bind'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,5 +3,5 @@ maintainer_email 'wolfe21@marshall.edu'
 license 'Apache 2.0'
 description 'Installs/Configures ISC BIND'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.3'
+version '1.0.4'
 name 'bind'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
-maintainer       'Eric G. Wolfe'
+maintainer 'Eric G. Wolfe'
 maintainer_email 'wolfe21@marshall.edu'
-license          'Apache 2.0'
-description      'Installs/Configures ISC BIND'
+license 'Apache 2.0'
+description 'Installs/Configures ISC BIND'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.3'
-name             'bind'
+version '1.0.3'
+name 'bind'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -113,7 +113,7 @@ template node['bind']['conf_file'] do
   group node['bind']['group']
   mode 00644
   variables(
-    zones: all_zones.uniq.sort
+    zones: all_zones.uniq.sort,
     forwardzones: forwardzones
   )
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -75,7 +75,7 @@ end
 # Create rndc key file, if it does not exist
 execute 'rndc-key' do
   command node['bind']['rndc_keygen']
-  not_if { ::File.exists?(node['bind']['rndc-key']) }
+  not_if { ::File.exist?(node['bind']['rndc-key']) }
 end
 
 file node['bind']['rndc-key'] do
@@ -98,7 +98,7 @@ all_zones = node['bind']['zones']['attribute'] + node['bind']['zones']['databag'
 template node['bind']['options_file'] do
   owner node['bind']['user']
   group node['bind']['group']
-  mode  00644
+  mode 00644
   variables(
     bind_acls: node['bind']['acls']
   )
@@ -120,5 +120,5 @@ service node['bind']['service_name'] do
   action [:enable, :start]
   subscribes :reload, resources("template[#{node['bind']['options_file']}]",
                                 "template[#{node['bind']['conf_file']}]"), :delayed
-  only_if { ::File.exists?(node['bind']['options_file']) && ::File.exists?(node['bind']['conf_file']) }
+  only_if { ::File.exist?(node['bind']['options_file']) && ::File.exist?(node['bind']['conf_file']) }
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 all_zones = []
+forwardzones = []
 
 # Read ACL objects from data bag.
 # These will be passed to the named.options template
@@ -93,6 +94,7 @@ else
 end
 
 all_zones = node['bind']['zones']['attribute'] + node['bind']['zones']['databag'] + node['bind']['zones']['ldap']
+forwardzones = node['bind']['forwardzones']
 
 # Render a template with all our global BIND options and ACLs
 template node['bind']['options_file'] do
@@ -112,6 +114,7 @@ template node['bind']['conf_file'] do
   mode 00644
   variables(
     zones: all_zones.uniq.sort
+    forwardzones: forwardzones
   )
 end
 

--- a/templates/default/named.conf.erb
+++ b/templates/default/named.conf.erb
@@ -27,6 +27,16 @@ zone "<%= zone %>" in {
 
 <% end -%>
 
+<% if @forwardzones.count > 0 do -%>
+<% @forwardzones.uniq.each do |forwardzone| -%>
+zone "<%= forwardzone %>" in {
+  type forward;
+  forwarders { <% node['bind']['forwarders'].each do |forwarder| %><%= forwarder %>; <% end %>};
+  forward only;
+};
+<% end -%>
+<% end -%>
+
 zone "." IN {
   type hint;
   file "named.ca";

--- a/templates/default/named.conf.erb
+++ b/templates/default/named.conf.erb
@@ -4,6 +4,16 @@
 include "<%= "#{node['bind']['sysconfdir']}/#{file}" %>";
 <% end -%>
 
+<% unless node['bind']['server'].empty? %>
+<% node['bind']['server'].each {|server_ip, options| %>
+server <%= server_ip %> {
+  <% options.each do |option| -%>
+  <%= option %>
+<% end -%>
+};
+<% } -%>
+<% end -%>
+
 <% @zones.uniq.each do |zone| -%>
 zone "<%= zone %>" in {
   type <%= node['bind']['zonetype'] %>;

--- a/templates/default/named.conf.erb
+++ b/templates/default/named.conf.erb
@@ -27,7 +27,7 @@ zone "<%= zone %>" in {
 
 <% end -%>
 
-<% if @forwardzones.count > 0 do -%>
+<% if @forwardzones.count > 0 -%>
 <% @forwardzones.uniq.each do |forwardzone| -%>
 zone "<%= forwardzone %>" in {
   type forward;


### PR DESCRIPTION
Support for 'server' clauses such as keys, bogus servers, etc. 
http://www.zytrax.com/books/dns/ch7/server.html has a good summary of options.
Also tested on Ubuntu 14.04